### PR TITLE
Add granular separation of crypto opcodes

### DIFF
--- a/lua/bitcoin-script-hints/op-codes.lua
+++ b/lua/bitcoin-script-hints/op-codes.lua
@@ -64,7 +64,11 @@ local OP_MAX = require('bitcoin-script-hints.op-codes.OP_MAX')
 local OP_WITHIN = require('bitcoin-script-hints.op-codes.OP_WITHIN')
 
 -- Crypto:
-local OP_HASH = require('bitcoin-script-hints.op-codes.OP_HASH')
+local OP_RIPEMD160 = require('bitcoin-script-hints.op-codes.OP_RIPEMD160')
+local OP_SHA1 = require('bitcoin-script-hints.op-codes.OP_SHA1')
+local OP_SHA256 = require('bitcoin-script-hints.op-codes.OP_SHA256')
+local OP_HASH160 = require('bitcoin-script-hints.op-codes.OP_HASH160')
+local OP_HASH256 = require('bitcoin-script-hints.op-codes.OP_HASH256')
 local OP_CHECKSIG = require('bitcoin-script-hints.op-codes.OP_CHECKSIG')
 local OP_CHECKSIGVERIFY = require('bitcoin-script-hints.op-codes.OP_CHECKSIGVERIFY')
 local OP_CHECKMULTISIG = require('bitcoin-script-hints.op-codes.OP_CHECKMULTISIG')
@@ -158,11 +162,11 @@ return {
   OP_WITHIN = OP_WITHIN,
 
   -- Crypto:
-  OP_RIPEMD160 = OP_HASH,
-  OP_SHA1 = OP_HASH,
-  OP_SHA256 = OP_HASH,
-  OP_HASH160 = OP_HASH,
-  OP_HASH256 = OP_HASH,
+  OP_RIPEMD160 = OP_RIPEMD160,
+  OP_SHA1 = OP_SHA1,
+  OP_SHA256 = OP_SHA256,
+  OP_HASH160 = OP_HASH160,
+  OP_HASH256 = OP_HASH256,
   OP_CODESEPARATOR = OP_NOP,
   OP_CHECKSIG = OP_CHECKSIG,
   OP_CHECKSIGVERIFY = OP_CHECKSIGVERIFY,

--- a/lua/bitcoin-script-hints/op-codes/OP_HASH160.lua
+++ b/lua/bitcoin-script-hints/op-codes/OP_HASH160.lua
@@ -8,6 +8,7 @@ return function(state)
   local new_state = vim.deepcopy(state)
   local val = table.remove(new_state.main)
   -- Create hashed representation by wrapping in H()
-  table.insert(new_state.main, "H(" .. tostring(val) .. ")")
+  table.insert(new_state.main, "HASH160(" .. tostring(val) .. ")")
   return new_state
 end
+

--- a/lua/bitcoin-script-hints/op-codes/OP_HASH256.lua
+++ b/lua/bitcoin-script-hints/op-codes/OP_HASH256.lua
@@ -1,0 +1,14 @@
+local utils = require('bitcoin-script-hints.utils')
+local make_error = utils.make_error
+
+return function(state)
+  if #state.main < 1 then
+    return make_error("Stack underflow", state)
+  end
+  local new_state = vim.deepcopy(state)
+  local val = table.remove(new_state.main)
+  -- Create hashed representation by wrapping in H()
+  table.insert(new_state.main, "HASH256(" .. tostring(val) .. ")")
+  return new_state
+end
+

--- a/lua/bitcoin-script-hints/op-codes/OP_RIPEMD160.lua
+++ b/lua/bitcoin-script-hints/op-codes/OP_RIPEMD160.lua
@@ -1,0 +1,13 @@
+local utils = require('bitcoin-script-hints.utils')
+local make_error = utils.make_error
+
+return function(state)
+  if #state.main < 1 then
+    return make_error("Stack underflow", state)
+  end
+  local new_state = vim.deepcopy(state)
+  local val = table.remove(new_state.main)
+  -- Create hashed representation by wrapping in H()
+  table.insert(new_state.main, "RIPEMD160(" .. tostring(val) .. ")")
+  return new_state
+end

--- a/lua/bitcoin-script-hints/op-codes/OP_SHA1.lua
+++ b/lua/bitcoin-script-hints/op-codes/OP_SHA1.lua
@@ -1,0 +1,13 @@
+local utils = require('bitcoin-script-hints.utils')
+local make_error = utils.make_error
+
+return function(state)
+  if #state.main < 1 then
+    return make_error("Stack underflow", state)
+  end
+  local new_state = vim.deepcopy(state)
+  local val = table.remove(new_state.main)
+  -- Create hashed representation by wrapping in H()
+  table.insert(new_state.main, "SHA1(" .. tostring(val) .. ")")
+  return new_state
+end

--- a/lua/bitcoin-script-hints/op-codes/OP_SHA256.lua
+++ b/lua/bitcoin-script-hints/op-codes/OP_SHA256.lua
@@ -1,0 +1,14 @@
+local utils = require('bitcoin-script-hints.utils')
+local make_error = utils.make_error
+
+return function(state)
+  if #state.main < 1 then
+    return make_error("Stack underflow", state)
+  end
+  local new_state = vim.deepcopy(state)
+  local val = table.remove(new_state.main)
+  -- Create hashed representation by wrapping in H()
+  table.insert(new_state.main, "SHA256(" .. tostring(val) .. ")")
+  return new_state
+end
+


### PR DESCRIPTION
My intention with this PR is to just separate the crypto opcodes into their respective opcode names to modify or visualize those opcodes better. as an example `OP_EQUAL` would not recognize the difference between any of these different hash functions as they all converged on `[H(A)]`